### PR TITLE
Xefu Spoofer v5 / Homebrew Store v5

### DIFF
--- a/UtilityScripts/HomebrewStore/Main.lua
+++ b/UtilityScripts/HomebrewStore/Main.lua
@@ -266,6 +266,8 @@ function GetScanPath(type)
 				return mountpoint .. v.Path .. "\\";
 			elseif type == "Game" and v.ScriptData == "Games" then
 				return mountpoint .. v.Path .. "\\";
+			elseif type == "PublicProfile" and v.ScriptData == "Live" then
+				return mountpoint .. v.Path .. "\\";
 			end
 		end
 	end

--- a/UtilityScripts/HomebrewStore/Main.lua
+++ b/UtilityScripts/HomebrewStore/Main.lua
@@ -1,6 +1,6 @@
 scriptTitle = "Homebrew Store"
 scriptAuthor = "Derf / Cheato"
-scriptVersion = 4.0
+scriptVersion = 5
 scriptDescription = "Download homebrew from ConsoleMods.org and other repos!"
 scriptIcon = "icon.png"
 scriptPermissions = { "http", "sql", "filesystem" }
@@ -422,10 +422,11 @@ function HandleInstallation(selection, destinationPath, type)
 		-- Download files
 		local dlpath = "";
 		local successfulMove = false;
+		local tmpRandomString = math.random(1,100000000);
 		if string.match(dataurl, ".7z") then
-			dlpath = downloadsPath .. "tmp.7z";
+			dlpath = downloadsPath .. "tmp-" .. tmpRandomString .. ".7z";
 		else
-			dlpath = downloadsPath .. "tmp.bin";
+			dlpath = downloadsPath .. "tmp-" .. tmpRandomString .. ".bin";
 		end
 
 		Script.SetStatus("Downloading content (" .. current_part_index .. "/" .. total_parts .. ")...");
@@ -464,7 +465,7 @@ function HandleInstallation(selection, destinationPath, type)
 					Script.SetProgress(loadingProgress+7);
 					Script.SetStatus("Moving content (" .. current_part_index .. "/" .. total_parts .. ")...");
 					partFileName = string.match(dataurl, "^.*/([^/]+)$");
-					successfulMove = FileSystem.CopyFile(absoluteDownloadsPath .. "tmp.bin", destinationFullPath .. partFileName, true, CopyProgressRoutine);
+					successfulMove = FileSystem.CopyFile(absoluteDownloadsPath .. "tmp-" .. tmpRandomString .. ".bin", destinationFullPath .. partFileName, true, CopyProgressRoutine);
 					Script.SetProgress(loadingProgress+9);
 				end
 

--- a/UtilityScripts/XefuSpoofer/Main.lua
+++ b/UtilityScripts/XefuSpoofer/Main.lua
@@ -1,6 +1,6 @@
 scriptTitle = "Xefu Spoofer"
 scriptAuthor = "Derf"
-scriptVersion = "4"
+scriptVersion = "5"
 scriptDescription = "Forces original Xbox games to use your selected xefu version. Compatibility list: ConsoleMods.org/fusion"
 scriptIcon = "icon.png"
 scriptPermissions = { "filesystem" }
@@ -13,6 +13,10 @@ xefubackup_folder = "Hddx:\\Compatibility\\XefuBackup\\";
 function main()
 	print("-- " .. scriptTitle .. " Started...");
 
+	if ParentalControlIsSet() == true then
+		Script.ShowMessageBox("WARNING","Parental Controls are enabled on your console.\n\nThis will likely prevent original Xbox games from booting!\n\nTo remove Parental Controls, visit:\nhttps://consolemods.org/wiki/Parental_Lock","OK");
+	end
+
 	if init() == false then
 		goto scriptend;
 	end
@@ -21,6 +25,21 @@ function main()
 	DoShowMenu();
 	
 	::scriptend::
+end
+
+-- Thanks jrobiche for this function!
+function ParentalControlIsSet()
+  -- Required Script Permissions: filesystem
+  -- Params: None
+  -- Returns:
+  --   true  - if PC is set
+  --   false - if PC is not set
+  --   nil   - if there was an issue loading the data containing PC information
+  local data=io.open("System:\\MobileB.dat", "rb"):read(67)
+  if data ~= nil then
+    return (string.byte(string.sub(data, 66, 67)) & 0x80) >> 7 == 1
+  end
+  return nil
 end
 
 function xefu_files_all_present(path)


### PR DESCRIPTION
Xefu Spoofer v5:
Adds a check and warning if parental controls are enabled, since it can interfere with original Xbox games running.

Homebrew Store v5:
Generate random filename for temporary download location to avoid downloads being broken after a failed extraction. 
This is a workaround for issue https://github.com/XboxUnity/AuroraScripts/issues/31